### PR TITLE
feat(token): finalize Table token with alias parsing and error support

### DIFF
--- a/internal/build/render/table.go
+++ b/internal/build/render/table.go
@@ -1,0 +1,36 @@
+package render
+
+import (
+	"fmt"
+
+	"github.com/ialopezg/entiqon/driver"
+	"github.com/ialopezg/entiqon/internal/build/token"
+)
+
+// Table renders a dialect-safe SQL representation of a table reference,
+// including optional aliasing using "AS". This does not prepend "FROM", "INTO", etc.
+//
+// If the table is not valid or has an error, an empty string is returned.
+//
+// # Examples
+//
+//	Table(driver, Table{Name: "users"})                     → "users"
+//	Table(driver, Table{Name: "users", Alias: "u"})         → "users AS u"
+func Table(d driver.Dialect, tbl token.Table) string {
+	if !tbl.IsValid() || tbl.HasError() {
+		return ""
+	}
+
+	if d == nil {
+		d = driver.NewGenericDialect()
+	}
+
+	name := d.QuoteIdentifier(tbl.Name)
+
+	if tbl.IsAliased() {
+		alias := d.QuoteIdentifier(tbl.Alias)
+		return fmt.Sprintf("%s AS %s", name, alias)
+	}
+
+	return name
+}

--- a/internal/build/render/table_test.go
+++ b/internal/build/render/table_test.go
@@ -1,0 +1,51 @@
+package render_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ialopezg/entiqon/driver"
+	"github.com/ialopezg/entiqon/internal/build/render"
+	"github.com/ialopezg/entiqon/internal/build/token"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderTable(t *testing.T) {
+	t.Run("ValidCases", func(t *testing.T) {
+		d := driver.NewGenericDialect()
+
+		tbl := token.NewTable("users")
+		assert.Equal(t, "users", render.Table(d, tbl))
+
+		tbl = token.NewTable("users AS u")
+		assert.Equal(t, "users AS u", render.Table(d, tbl))
+
+		tbl = token.NewTable("users", "u")
+		assert.Equal(t, "users AS u", render.Table(d, tbl))
+	})
+
+	t.Run("ValidCases", func(t *testing.T) {
+		d := driver.NewGenericDialect()
+
+		tbl := token.NewErroredTable(fmt.Errorf("invalid"))
+		assert.Equal(t, "", render.Table(d, tbl))
+
+		tbl = token.NewTable("users AS x", "y") // alias mismatch
+		assert.Equal(t, "", render.Table(d, tbl))
+
+		tbl = token.NewTable("users, orders") // comma not allowed
+		assert.Equal(t, "", render.Table(d, tbl))
+	})
+
+	t.Run("With", func(t *testing.T) {
+		t.Run("NilDialect", func(t *testing.T) {
+			tbl := token.NewTable("users AS u")
+			assert.Equal(t, "users AS u", render.Table(nil, tbl)) // fallback to generic
+		})
+
+		t.Run("PostgresDialect", func(t *testing.T) {
+			tbl := token.NewTable("users AS u")
+			assert.Equal(t, "\"users\" AS \"u\"", render.Table(driver.NewPostgresDialect(), tbl))
+		})
+	})
+}

--- a/internal/build/token/base.go
+++ b/internal/build/token/base.go
@@ -46,6 +46,18 @@ type BaseToken struct {
 	Error error
 }
 
+// NewErroredToken creates a BaseToken containing the provided error.
+//
+// This is used when a token (e.g., Column, Table) cannot be parsed or resolved
+// and must be retained in the token stream for error reporting and validation.
+//
+// # Example:
+//
+//	col := Column{BaseToken: NewErroredToken(fmt.Errorf("empty input"))}
+func NewErroredToken(err error) BaseToken {
+	return BaseToken{Error: err}
+}
+
 // HasError reports whether the token has encountered a semantic or structural error.
 //
 // Typical causes include alias mismatches, unresolved references, or conflicting

--- a/internal/build/token/column.go
+++ b/internal/build/token/column.go
@@ -74,11 +74,7 @@ func NewColumn(expr string, alias ...string) Column {
 //
 // Since: v1.6.0
 func NewErroredColumn(err error) Column {
-	return Column{
-		BaseToken: BaseToken{
-			Error: err,
-		},
-	}
+	return Column{BaseToken: NewErroredToken(err)}
 }
 
 // IsQualified reports whether the column has a table prefix.

--- a/internal/build/token/table.go
+++ b/internal/build/token/table.go
@@ -1,0 +1,123 @@
+// filename: internal/build/token/table.go
+
+package token
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Table represents a SQL table reference, typically used in FROM, INTO, or JOIN clauses.
+//
+// It embeds BaseToken to track the name, optional alias, and semantic error state.
+// A Table token can be qualified with an alias (e.g., "users AS u") but does not support
+// column-level detail — it represents the table object only.
+//
+// Since: v1.6.0
+type Table struct {
+	BaseToken
+}
+
+// NewErroredTable creates a Table token with an attached error.
+//
+// This is used when a table reference fails parsing, validation, or resolution.
+// The resulting Table will have its Name and Alias unset, and the provided
+// error will be stored in its BaseToken for tracking and diagnostics.
+//
+// # Example
+//
+//	tbl := token.NewErroredTable(fmt.Errorf("empty table reference"))
+//	fmt.Println(tbl.String())
+//
+//	// Output:
+//	Table("") [aliased: false, errored: true, error: empty table reference]
+//
+// This constructor allows builders and parsers to retain structurally invalid
+// tokens in the build stream while still reporting errors through validators.
+func NewErroredTable(err error) Table {
+	return Table{BaseToken: NewErroredToken(err)}
+}
+
+// NewTable creates a Table token from an expression and optional alias.
+//
+// Supports aliasing via:
+//   - "AS" keyword: "users AS u"
+//   - space-delimited: "users u"
+//
+// If an inline alias and explicit alias are both present but conflict,
+// the returned Table includes an error.
+//
+// Comma-separated expressions are not allowed and result in an errored Table.
+//
+// # Examples:
+//
+//	NewTable("users")                    → Table{Name: "users"}
+//	NewTable("users AS u")               → Table{Name: "users", Alias: "u"}
+//	NewTable("users", "u")               → Table{Name: "users", Alias: "u"}
+//	NewTable("users AS x", "y")          → Table{Error: alias mismatch}
+//	NewTable("users, orders")            → Table{Error: comma-separated input not allowed}
+func NewTable(expr string, alias ...string) Table {
+	if strings.Contains(expr, ",") {
+		return NewErroredTable(fmt.Errorf("comma-separated input not allowed in NewTable: %q", expr))
+	}
+
+	var err error
+	base, parsedAlias := ParseAlias(expr)
+	if base == "" {
+		return NewErroredTable(fmt.Errorf("source table is empty"))
+	}
+
+	var finalAlias string
+	if len(alias) > 0 {
+		finalAlias = alias[0]
+		if parsedAlias != "" && parsedAlias != finalAlias {
+			err = fmt.Errorf("alias mismatch: inline alias '%s' ≠ provided alias '%s'", parsedAlias, finalAlias)
+		}
+	} else {
+		finalAlias = parsedAlias
+	}
+
+	return Table{
+		BaseToken: BaseToken{
+			Name:  base,
+			Alias: finalAlias,
+			Error: err,
+		},
+	}
+}
+
+// Raw returns the SQL-safe table reference, including alias if present.
+//
+// This output is not dialect-quoted. Quoting should be handled during rendering.
+//
+// # Examples
+//
+//	Table{Name: "users"} → "users"
+//	Table{Name: "users", Alias: "u"} → "users AS u"
+func (t Table) Raw() string {
+	if t.IsAliased() {
+		return fmt.Sprintf("%s AS %s", t.Name, t.Alias)
+	}
+	return t.Name
+}
+
+// String returns a debug-friendly view of the Table token.
+//
+// The output includes the table name, alias status, and error state if applicable.
+// This is intended for logging and diagnostics, not SQL rendering.
+//
+// # Example Output
+//
+//	Table("users") [aliased: false, errored: false]
+//	Table("users") [aliased: true, errored: true, error: alias mismatch]
+func (t Table) String() string {
+	s := fmt.Sprintf("Table(%q) [aliased: %v, errored: %v", t.Name, t.IsAliased(), t.HasError())
+	if t.HasError() {
+		s += fmt.Sprintf(", error: %s", t.Error.Error())
+	}
+	s += "]"
+	return s
+}
+
+// Ensure Table satisfies the GenericToken interface.
+var _ GenericToken = Table{}


### PR DESCRIPTION
- Implements NewTable with inline and explicit alias handling
- Adds NewErroredTable constructor for clean error propagation
- Ensures comma-separated input and alias mismatch produce structured errors
- Includes Raw() and String() methods for diagnostics and rendering support
- Table token now matches Column’s robustness and builder readiness

Since: v1.6.0